### PR TITLE
fix: Formatting on pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 
 # Disable concurent to run build-types after ESLint in lint-staged
 npx lint-staged --concurrent false
-yarn test
+npm test

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  '*.{js,jsx,ts,tsx}': ['eslint --fix', 'eslint'],
+  '*.{js,jsx,ts,tsx}': ['prettier --write', 'eslint --fix'],
   '**/*.ts?(x)': () => 'npm run build-types',
-  '*.json': ['prettier --write'],
+  '*.{json,md,css,scss,html,yml,yaml}': ['prettier --write'],
 };


### PR DESCRIPTION
### Summary:
Fix Husky pre-commit hook to run lint-staged formatting/linting and use npm test instead of yarn.

### What changed:
` lint-staged` now runs `Prettier` on staged JS/TS + common text files and runs `ESLint` autofix; TypeScript typecheck still runs via `build-types`.
 
### Test plan:
 Stage a JS/TS file, run git commit, confirm `Prettier/ESLint run;` confirm tests run via `npm test.`